### PR TITLE
Added BGM and SFX controls

### DIFF
--- a/Assets/Music/SFX/crash1.wav.meta
+++ b/Assets/Music/SFX/crash1.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 4bcde6de2166e41e284ec46d8a01fb90
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Music/SFX/crash2.wav.meta
+++ b/Assets/Music/SFX/crash2.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 913d6445ee8cc4152a9c18da590ee203
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Music/SFX/crash3.wav.meta
+++ b/Assets/Music/SFX/crash3.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: e7ee25a47d63b46cdaf65480d62b405c
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Music/SFX/jump1.wav.meta
+++ b/Assets/Music/SFX/jump1.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 08ab7053d586c458db3774d33c141a4b
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Music/SFX/jump2.wav.meta
+++ b/Assets/Music/SFX/jump2.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 0f7d0b7c3397f4dac91f20e8a77d2d57
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
-  forceToMono: 0
+  forceToMono: 1
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Music/SFX/jump3.wav.meta
+++ b/Assets/Music/SFX/jump3.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 113ee460fadc340e4957a7404a9fbb27
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 7
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/Assets/Prefabs/Particles/Explosion_Blue.prefab
+++ b/Assets/Prefabs/Particles/Explosion_Blue.prefab
@@ -44,7 +44,7 @@ ParticleSystem:
   serializedVersion: 8
   lengthInSec: 0.1
   simulationSpeed: 1
-  stopAction: 0
+  stopAction: 2
   cullingMode: 3
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
@@ -4845,7 +4845,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3603594204106460700}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 62687fb045497b5499c8f690d3a4247a, type: 3}
   m_Name: 

--- a/Assets/Scenes/CharacterSelect.unity
+++ b/Assets/Scenes/CharacterSelect.unity
@@ -472,6 +472,152 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &326784927
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 326784930}
+  - component: {fileID: 326784929}
+  - component: {fileID: 326784928}
+  m_Layer: 0
+  m_Name: SfxPlayer
+  m_TagString: SfxPlayer
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!82 &326784928
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 326784927}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 256
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!114 &326784929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 326784927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2878f866554d3604c81a9422c1c012e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cameraReference: {fileID: 0}
+  shootingSfx: {fileID: 8300000, guid: 08ab7053d586c458db3774d33c141a4b, type: 3}
+  impactSfx: {fileID: 8300000, guid: e7ee25a47d63b46cdaf65480d62b405c, type: 3}
+  killSfx: {fileID: 8300000, guid: 913d6445ee8cc4152a9c18da590ee203, type: 3}
+  oneShot: {fileID: 326784928}
+--- !u!4 &326784930
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 326784927}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.429262, y: 0.32848477, z: 0.7468938}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &327600967
 GameObject:
   m_ObjectHideFlags: 0
@@ -1726,6 +1872,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterSelectManager: {fileID: 1377872786}
   selectIcon: {fileID: 1372119944}
+  pointerEnterSfx: {fileID: 8300000, guid: 113ee460fadc340e4957a7404a9fbb27, type: 3}
+  pointerSelectSfx: {fileID: 8300000, guid: 0f7d0b7c3397f4dac91f20e8a77d2d57, type: 3}
+  pointerExitSfx: {fileID: 8300000, guid: 08ab7053d586c458db3774d33c141a4b, type: 3}
 --- !u!1 &1377872786
 GameObject:
   m_ObjectHideFlags: 0
@@ -2603,6 +2752,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterSelectManager: {fileID: 1377872786}
   selectIcon: {fileID: 1643679334}
+  pointerEnterSfx: {fileID: 8300000, guid: 113ee460fadc340e4957a7404a9fbb27, type: 3}
+  pointerSelectSfx: {fileID: 8300000, guid: 0f7d0b7c3397f4dac91f20e8a77d2d57, type: 3}
+  pointerExitSfx: {fileID: 8300000, guid: 08ab7053d586c458db3774d33c141a4b, type: 3}
 --- !u!1 &1702505835
 GameObject:
   m_ObjectHideFlags: 0
@@ -3472,3 +3624,4 @@ SceneRoots:
   - {fileID: 1702505839}
   - {fileID: 324702488}
   - {fileID: 1579172253}
+  - {fileID: 326784930}

--- a/Assets/Scenes/CharacterSelect.unity
+++ b/Assets/Scenes/CharacterSelect.unity
@@ -1203,6 +1203,7 @@ GameObject:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
+  - component: {fileID: 963194229}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1284,6 +1285,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 35, y: 0, z: 0}
+--- !u!114 &963194229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7f97584c4bf1fa4fb103b57223b23cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trackIndex: 6
 --- !u!1 &1040484942
 GameObject:
   m_ObjectHideFlags: 0
@@ -2175,6 +2189,157 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1558296498}
   m_CullTransparentMesh: 1
+--- !u!1 &1579172250
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1579172253}
+  - component: {fileID: 1579172252}
+  - component: {fileID: 1579172251}
+  m_Layer: 0
+  m_Name: MusicPlayer
+  m_TagString: MusicPlayer
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!82 &1579172251
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1579172250}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 0.5
+  m_Pitch: 1
+  Loop: 1
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!114 &1579172252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1579172250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cb411d82b0ef244bab9d5875b06a149, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tracklist:
+  - {fileID: 8300000, guid: 03c5ee25d0c23234d95d49f7cf4bfedc, type: 3}
+  - {fileID: 8300000, guid: ef827585e7e9b5244ab00f3a3752c517, type: 3}
+  - {fileID: 8300000, guid: 8aa9a403ae8bc8b40850511abb737e66, type: 3}
+  - {fileID: 8300000, guid: fd6796de551f9ff40af07e58f7b67c5c, type: 3}
+  - {fileID: 8300000, guid: e11612874ab88254aabdd0097959257f, type: 3}
+  - {fileID: 8300000, guid: ce3a8f43f4eee2c428326a0cf7c580c8, type: 3}
+  - {fileID: 8300000, guid: adc3adbcc35e97b47bea5f3547155277, type: 3}
+  cameraReference: {fileID: 0}
+  music: {fileID: 1579172251}
+--- !u!4 &1579172253
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1579172250}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.429262, y: 0.32848477, z: 0.7468938}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1625096692
 GameObject:
   m_ObjectHideFlags: 0
@@ -3306,3 +3471,4 @@ SceneRoots:
   - {fileID: 963194228}
   - {fileID: 1702505839}
   - {fileID: 324702488}
+  - {fileID: 1579172253}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2012,152 +2012,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gameManager: {fileID: 1005037242}
   card: {fileID: 253422237}
---- !u!1 &326784927
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 326784930}
-  - component: {fileID: 326784929}
-  - component: {fileID: 326784928}
-  m_Layer: 0
-  m_Name: SfxPlayer
-  m_TagString: SfxPlayer
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!82 &326784928
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 326784927}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 0
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 256
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!114 &326784929
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 326784927}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2878f866554d3604c81a9422c1c012e8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  cameraReference: {fileID: 963194225}
-  shootingSfx: {fileID: 8300000, guid: 08ab7053d586c458db3774d33c141a4b, type: 3}
-  impactSfx: {fileID: 8300000, guid: e7ee25a47d63b46cdaf65480d62b405c, type: 3}
-  killSfx: {fileID: 8300000, guid: 913d6445ee8cc4152a9c18da590ee203, type: 3}
-  oneShot: {fileID: 326784928}
---- !u!4 &326784930
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 326784927}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.429262, y: 0.32848477, z: 0.7468938}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &329123616
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5812,6 +5666,7 @@ GameObject:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
+  - component: {fileID: 963194229}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -5893,6 +5748,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 35, y: 0, z: 0}
+--- !u!114 &963194229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7f97584c4bf1fa4fb103b57223b23cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trackIndex: 0
 --- !u!1 &982031883
 GameObject:
   m_ObjectHideFlags: 0
@@ -8934,157 +8802,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1577245129}
   m_CullTransparentMesh: 1
---- !u!1 &1579172250
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1579172253}
-  - component: {fileID: 1579172252}
-  - component: {fileID: 1579172251}
-  m_Layer: 0
-  m_Name: MusicPlayer
-  m_TagString: MusicPlayer
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!82 &1579172251
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1579172250}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 0
-  m_Volume: 0.3
-  m_Pitch: 1
-  Loop: 1
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!114 &1579172252
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1579172250}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cb411d82b0ef244bab9d5875b06a149, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tracklist:
-  - {fileID: 8300000, guid: 03c5ee25d0c23234d95d49f7cf4bfedc, type: 3}
-  - {fileID: 8300000, guid: ef827585e7e9b5244ab00f3a3752c517, type: 3}
-  - {fileID: 8300000, guid: 8aa9a403ae8bc8b40850511abb737e66, type: 3}
-  - {fileID: 8300000, guid: fd6796de551f9ff40af07e58f7b67c5c, type: 3}
-  - {fileID: 8300000, guid: e11612874ab88254aabdd0097959257f, type: 3}
-  - {fileID: 8300000, guid: ce3a8f43f4eee2c428326a0cf7c580c8, type: 3}
-  - {fileID: 8300000, guid: adc3adbcc35e97b47bea5f3547155277, type: 3}
-  cameraReference: {fileID: 963194225}
-  music: {fileID: 1579172251}
---- !u!4 &1579172253
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1579172250}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.429262, y: 0.32848477, z: 0.7468938}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1608878361
 GameObject:
   m_ObjectHideFlags: 0
@@ -12411,7 +12128,5 @@ SceneRoots:
   - {fileID: 565976062}
   - {fileID: 506205516}
   - {fileID: 599618613}
-  - {fileID: 1579172253}
-  - {fileID: 326784930}
   - {fileID: 883648983}
   - {fileID: 929420405}

--- a/Assets/Scripts/GUI Managers/CharacterSelect/CharacterSelectIconManager.cs
+++ b/Assets/Scripts/GUI Managers/CharacterSelect/CharacterSelectIconManager.cs
@@ -2,23 +2,43 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.UIElements;
 
 public class CharacterSelectIconManager : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler {
 
+    [Header("SELECTION")]
 		[SerializeField] private GameObject characterSelectManager;
     [SerializeField] private GameObject selectIcon;
-
     private bool isSelected = false;
+
+    [Header("SFX")]
+     private SfxManager sfxManager;
+     [SerializeField] private AudioClip pointerEnterSfx;
+     [SerializeField] private AudioClip pointerSelectSfx;
+
+     [SerializeField] private AudioClip pointerExitSfx;
+
+
+    /// <summary>
+    /// Start is called on the frame when a script is enabled just before
+    /// any of the Update methods is called the first time.
+    /// </summary>
+    void Start()
+    {
+        sfxManager = GameObject.Find("SfxPlayer").GetComponent<SfxManager>();
+    }
 
     public void OnPointerEnter(PointerEventData eventData) {
       if (!isSelected){
+        sfxManager.PlayOneShot(pointerEnterSfx);
         selectIcon.transform.Find("Background").GetComponent<UnityEngine.UI.Outline>().effectColor = new Color((float) 73/255, 1, 1, (float) 138/255);
 				characterSelectManager.GetComponent<CharacterSelectManager>().OnIconHoverIn(selectIcon.name);
       }
     }
 
     public void OnPointerExit(PointerEventData eventData) {
-      if (!isSelected){    
+      if (!isSelected){
+        sfxManager.PlayOneShot(pointerExitSfx);
         selectIcon.transform.Find("Background").GetComponent<UnityEngine.UI.Outline>().effectColor = new Color(1, 1, 1, (float) 138/255);
 				characterSelectManager.GetComponent<CharacterSelectManager>().OnIconHoverOut();
       }
@@ -26,6 +46,7 @@ public class CharacterSelectIconManager : MonoBehaviour, IPointerEnterHandler, I
     
     public void OnPointerDown(PointerEventData eventData) {
       if (!isSelected){
+        sfxManager.PlayOneShot(pointerSelectSfx);
         isSelected = true;
         selectIcon.transform.Find("Background").GetComponent<UnityEngine.UI.Outline>().effectColor = new Color((float) 73/255, 1, (float) 73/255, (float) 138/255);
         characterSelectManager.GetComponent<CharacterSelectManager>().SelectCharacter(selectIcon.name);

--- a/Assets/Scripts/GUI Managers/CharacterSelect/CharacterSelectManager.cs
+++ b/Assets/Scripts/GUI Managers/CharacterSelect/CharacterSelectManager.cs
@@ -20,13 +20,11 @@ public class CharacterSelectManager : MonoBehaviour {
 
     public bool isCharacterSelected = false;
 
-
     void Start() {
       header.gameObject.transform.localPosition = new Vector3(1200, 210, 0);
       characterSplash.gameObject.transform.localPosition = new Vector3(-700, -160, 0);
       characterNameObject.GetComponent<TMP_Text>().text = "";
       characterDescriptionObject.GetComponent<TMP_Text>().text = "";
-
       StartCoroutine(SceneStart());
     }
 

--- a/Assets/Scripts/MusicPlayer.cs
+++ b/Assets/Scripts/MusicPlayer.cs
@@ -9,6 +9,8 @@ public class MusicPlayer : MonoBehaviour
     [SerializeField] private AudioSource music;
     private static MusicPlayer _instance;
 
+    private bool isTestingMusic = false;
+    
     public static MusicPlayer Instance
     {
         get { return _instance; }
@@ -34,8 +36,9 @@ public class MusicPlayer : MonoBehaviour
     //  Start is called before the first frame update
     void Start()
     {   
-        if (!music.isPlaying) {
-            transform.position = cameraReference.transform.position;
+        cameraReference = GameObject.FindGameObjectWithTag("MainCamera");
+        transform.position = cameraReference.transform.position;
+        if (!music.isPlaying && isTestingMusic) {
             PlayRandomTrack();
         }
     }
@@ -49,6 +52,13 @@ public class MusicPlayer : MonoBehaviour
     {
         music.clip = track;
     }
+
+    public void PlayTrack(int trackIndex)
+    {
+        SetTrack(tracklist[trackIndex]);
+        Play();
+    }
+
 
     public void PlayRandomTrack()
     {

--- a/Assets/Scripts/Scene.meta
+++ b/Assets/Scripts/Scene.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8dfe8339245c5bc48aecc84986f88048
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scene/OnStartBGM.cs
+++ b/Assets/Scripts/Scene/OnStartBGM.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class OnStartBGM : MonoBehaviour
+{
+
+    private MusicPlayer musicPlayer;
+
+    [SerializeField] private int trackIndex;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        musicPlayer = GameObject.FindGameObjectWithTag("MusicPlayer").GetComponent<MusicPlayer>();
+        musicPlayer.PlayTrack(trackIndex);
+    }
+
+}

--- a/Assets/Scripts/Scene/OnStartBGM.cs.meta
+++ b/Assets/Scripts/Scene/OnStartBGM.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7f97584c4bf1fa4fb103b57223b23cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SfxManager.cs
+++ b/Assets/Scripts/SfxManager.cs
@@ -36,6 +36,7 @@ public class SfxManager : MonoBehaviour
     //  Start is called before the first frame update
     void Start()
     {   
+        cameraReference = GameObject.FindGameObjectWithTag("MainCamera");
         transform.position = cameraReference.transform.position;
     }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,11 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/CharacterSelect.unity
+    guid: d5be999731eb8024684149f1f8fef48f
+  - enabled: 1
+    path: Assets/Scenes/Game.unity
+    guid: 776b32c9113c41442a9b46e045147482
   m_configObjects: {}

--- a/ProjectSettings/TimelineSettings.asset
+++ b/ProjectSettings/TimelineSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 53
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a287be6c49135cd4f9b2b8666c39d999, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assetDefaultFramerate: 60
+  m_DefaultFrameRate: 60


### PR DESCRIPTION
We hook OnStartBGM to the MainCamera of each scene just to set the scene's starting BGM. We can add a separate BGMManager object later if coupling becomes an issue. We can also dynamically set the BGM with setters exposed by MusicPlayer on events across the scene (eg. boss fight).

Suggestions: Find voice lines unique to each VTuber so we can have unique selection voicelines in CharacterSelect. The interface has already been implemented. See CharacterSelect.CharacterSelectUI.CharacterSelectIcons. I hook my SFX events on the pointer events defined in the corresponding scripts of each character and serialize each sfx so we can eventually set a different one for each VTuber.